### PR TITLE
Modify siad  to allow non-localhost API port when security is disabled

### DIFF
--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -42,11 +42,6 @@ func verifyAPISecurity(config Config) error {
 		return nil
 	}
 
-	// If the --disable-api-security flag is used, enforce that
-	// --authenticate-api must also be used.
-	if config.Siad.AllowAPIBind && !config.Siad.AuthenticateAPI {
-		return errors.New("cannot use --disable-api-security without setting an api password")
-	}
 	return nil
 }
 

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -142,14 +142,14 @@ func TestVerifyAPISecurity(t *testing.T) {
 		t.Error("public + securityOn was accepted")
 	}
 
-	// Check that a public hostname is rejected when security is disabled and
-	// there is no api password.
+	// Check that a public hostname is accepted when security is disabled
+	// and there is no api password.
 	var securityOffPublic Config
 	securityOffPublic.Siad.APIaddr = "sia.tech:9980"
 	securityOffPublic.Siad.AllowAPIBind = true
 	err = verifyAPISecurity(securityOffPublic)
-	if err == nil {
-		t.Error("public + securityOff was accepted without authentication")
+	if err != nil {
+		t.Error("public + securityOff was rejected")
 	}
 
 	// Check that a public hostname is accepted when security is disabled and


### PR DESCRIPTION
Changes the behavior of the siad command line processor to allow the user to
bind to a non-local interfact to listen for API calls when the user has passed
the --disable-api-security flag.
