### PR TITLE
Remove unused contractor constants

### DIFF
--- a/modules/renter/contractor/consts.go
+++ b/modules/renter/contractor/consts.go
@@ -8,13 +8,6 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// Constants related to fees and fee estimation.
-const (
-	// estimatedFileContractTransactionSize provides the estimated size of
-	// the average file contract in bytes.
-	estimatedFileContractTransactionSize = 1200
-)
-
 // Constants related to contract formation parameters.
 var (
 	// To alleviate potential block propagation issues, the contractor sleeps
@@ -29,28 +22,6 @@ var (
 	// total contract cost below which the contractor will prematurely renew a
 	// contract.
 	minContractFundRenewalThreshold = float64(0.03) // 3%
-
-	// minHostsForEstimations describes the minimum number of hosts that
-	// are needed to make broad estimations such as the number of sectors
-	// that you can store on the network for a given allowance.
-	minHostsForEstimations = build.Select(build.Var{
-		// The number is set lower than standard so that it can
-		// be reached/exceeded easily within development
-		// environments, but set high enough that it's also
-		// easy to fall short within the development
-		// environments.
-		Dev: 5,
-		// Hosts can have a lot of variance. Selecting too many
-		// hosts will high-ball the price estimation, but users
-		// shouldn't be selecting rewer hosts, and if there are
-		// too few hosts being selected for estimation there is
-		// a risk of underestimating the actual price, which is
-		// something we'd rather avoid.
-		Standard: 10,
-		// Testing tries to happen as fast as possible,
-		// therefore tends to run with a lot fewer hosts.
-		Testing: 4,
-	}).(int)
 
 	// minScoreHostBuffer defines how many extra hosts are queried when trying
 	// to figure out an appropriate minimum score for the hosts that we have.


### PR DESCRIPTION
Remove constants estimatedFileContractTransactionSize and minHostsForEstimations which are unused and just dead code.